### PR TITLE
Add a wrapper script and revise model README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ env/*
 node_modules/*
 model/node_modules/*
 model/chain/node_modules/*
+model/chain/ganache_output.txt
+model/chain/deploy_output.txt
+model/chain/log.tsv
+model/chain/db
+model/chain/db/*
+model/chain/venv
+model/chain/venv/*

--- a/model/chain/README.md
+++ b/model/chain/README.md
@@ -14,34 +14,18 @@ First, you need to install the dependencies in this directory:
 npm install
 ```
 
-Then, you need Ganache running. Note that you may need to `npm install -g` it first. You also need to raise its default gas limit.
+Then, you need Ganache and Truffle installed:
 
 ```
-ganache-cli --p 7545 --gasLimit 8000000 --accounts 2000 --defaultBalanceEther 1000000
+npm install -g ganache-cli
+npm install -g truffle
 ```
 
-Then, you can deploy into Ganache with Truffle (which you also may need to `npm install -g`).
+Finally, you can run the wrapper script, which will start Ganache, deploy the contracts into it, install necessary Python dependencies, run the `model.py` modeling script, and clean up temporary files afterward.
 
 ```
-truffle migrate --network=development | tee deploy_output.txt
+./run.sh
 ```
-
-Then, you can run a model against the chain. For that, you probably want a Python virtual environment:
-
-```
-virtualenv --python python3 venv
-. venv/bin/activate
-```
-
-And you will need to install the dependencies for the Python model:
-
-```
-pip3 install -r requirements.txt
-```
-
-
-TODO: Implement something with pyweb3 that can share agents and action representations with integrated Python version?
-
 
 
 

--- a/model/chain/run.sh
+++ b/model/chain/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# run.sh: run the model against a clean testnet, and clean up afterwards
+
+set -e
+
+# We keep our Ganache database right here, in ./db, because one time it
+# entirely hosed a system by taking up the whole /tmp. Note that it can quickly
+# and easily grow to tens of thousands of files! Make sure you have the inodes
+# to spare!
+
+# Clean it out
+echo "Cleaning Old Database..."
+rm -Rf db
+
+# Have a function to kill off Ganache and clean up the database when we quit.
+function cleanup {
+    echo "Stopping Ganache (${GANACHE})..."
+    # Kill Ganache if not dead already
+    kill "${GANACHE}" 2>/dev/null || true
+    # Clean database
+    echo "Cleaning Up Database..."
+    rm -Rf db
+}
+
+trap cleanup EXIT
+
+# Start the chain
+echo "Starting Ganache..."
+TMPDIR="$(pwd)" ganache-cli --p 7545 --gasLimit 8000000 --accounts 2000 --defaultBalanceEther 1000000 --db ./db >ganache_output.txt &
+GANACHE=$!
+
+# Wait for it to come up
+echo "Waiting for Ganache..."
+while ! grep "^Listening on" ganache_output.txt 2>/dev/null ; do
+    sleep 1
+done
+
+# Run the deployment
+echo "Deploying contracts..."
+truffle migrate --reset --network=development | tee deploy_output.txt
+
+if [[ ! -e venv ]] ; then
+    # Set up the virtual environment
+    echo "Preparing Virtual Environment..."
+    virtualenv --python python3 venv
+    . venv/bin/activate
+    pip3 install -r requirements.txt
+else
+    # Just go into it
+    echo "Entering Virtual Environment..."
+    . venv/bin/activate
+fi
+
+# Run the model
+echo "Running Model..."
+./model.py
+
+
+
+


### PR DESCRIPTION
This should keep Ganache safely contained next to the source code. It still wants to use 10s of thousands of files (although I bet reducing `--addresses` could bring that down a bit), but if you use the `run.sh` script those files will be in the `db` directory and will get cleaned up when you stop the model.

You also get a fresh deploy automatically every time this way.