### PR TITLE
Add Token Proxies

### DIFF
--- a/model/chain/README.md
+++ b/model/chain/README.md
@@ -27,5 +27,13 @@ Finally, you can run the wrapper script, which will start Ganache, deploy the co
 ./run.sh
 ```
 
+If you are editing the model, you can run:
+
+```
+RUN_SHELL=1 ./run.sh
+```
+
+Then you can run `./model.py` in that shell multiple times, against the same prepared chain. To tear down the chain, just `exit`.
+
 
 

--- a/model/chain/model.py
+++ b/model/chain/model.py
@@ -497,8 +497,6 @@ class Agent:
         self.uniswap_pair = uniswap_pair
 
         self.is_uniswap_approved = False
-        self.is_xsd_approved = False
-        self.is_dao_approved = False
 
         # keeps track of latest block seen for nonce tracking/tx
         self.seen_block = {}

--- a/model/chain/model.py
+++ b/model/chain/model.py
@@ -825,6 +825,12 @@ class DAO:
     def epoch(self, address):
         return self.contract.caller({'from' : address, 'gas': 8000000}).epoch()
         
+    def has_coupon_bid(self):
+        """
+        Return True if the DAO implements coupon bidding.
+        """
+        return hasattr(self.contract.functions, 'placeCouponAuctionBid')
+        
     def coupon_bid(self, agent, coupon_expiry, xsd_amount, max_coupon_amount):
         """
         Place a coupon bid
@@ -1039,7 +1045,7 @@ class Model:
                 options.append("unbond")
             '''
             # no point in buying coupons untill theres at least 10k usdc in the pool (so like 80-100 epoch effective warmup)
-            if a.xsd > 0 and epoch_start_price < 1.0 and self.dao.epoch(a.address) > self.bootstrap_epoch and self.min_usdc_balance <= usdc_b:
+            if a.xsd > 0 and epoch_start_price < 1.0 and self.dao.epoch(a.address) > self.bootstrap_epoch and self.min_usdc_balance <= usdc_b and self.dao.has_coupon_bid():
                 options.append("coupon_bid")
             # try any ways but handle traceback, faster than looping over all the epocks
             if epoch_start_price > 1.0 and total_coupons > 0 and self.dao.total_coupons_for_agent(a):

--- a/model/chain/run.sh
+++ b/model/chain/run.sh
@@ -51,6 +51,10 @@ else
     . venv/bin/activate
 fi
 
+
+sleep infinity
+exit
+
 # Run the model
 echo "Running Model..."
 ./model.py

--- a/model/chain/run.sh
+++ b/model/chain/run.sh
@@ -51,13 +51,15 @@ else
     . venv/bin/activate
 fi
 
-
-sleep infinity
-exit
-
-# Run the model
-echo "Running Model..."
-./model.py
+if [[ "${RUN_SHELL}" == "1" ]] ; then
+    # Run a shell so that you can run the model several times
+    echo "Running Interactive Shell..."
+    bash
+else
+    # Run the model
+    echo "Running Model..."
+    ./model.py
+fi
 
 
 


### PR DESCRIPTION
This adds a `TokenProxy` object that keep a Python-side idea of everyone's balances, in a way that tracks chain updates with events, rather than by manually adding and subtracting when operations happen. They also have functions to simplify approval management.

It's implemented for USDC and xSD so far; it could also be used for the DAO shares, Uniswap shares, and I think also LP pool shares?

I can't quite test the merged version since the new nonce computation isn't done, but before I merged your branch in, I definitely had it working.

Also, this lets you `RUN_SHELL=1 ./run.sh` so you can let the script set up Ganache for you and then run the model against it repeatedly from the shell it drops you into.